### PR TITLE
Basic interactive prompts for `init` + refactoring

### DIFF
--- a/sohoj/creator.py
+++ b/sohoj/creator.py
@@ -5,24 +5,25 @@ from datetime import datetime
 def create_config(project_folder, user_choices):
     # Default name is config.yml + located in root of project folder
     config_file_path = path.join(project_folder, 'config.yml')
-    url = user_choices[0] if (user_choices[0] is not None) else 'yourdomain.tld', 
-    desc = user_choices[1] if (user_choices[1] is not None) else 'Just another little corner on the interwebs', 
-    a = '' if ( user_choices[2] == 'Y' ) else '#'
-    print(f"Choices:\nSite URL: {url}\nSite Description: {desc}\nCustom: {a}")
+    default_conf_values = ['yourdomain.tld','Just another little corner on the interwebs.', '#']
+    # Only set user prompts if they are NOT NONE + NOT JUST EMPTY SPACES (else no real validation done)
+    url = user_choices[0] if ( user_choices[0] and user_choices[0].strip()) else default_conf_values[0] 
+    desc = user_choices[1] if ( user_choices[1] and user_choices[1].strip()) else default_conf_values[1]
+    custom_needed = user_choices[-1] if ( user_choices[-1] and user_choices[-1].strip()) else default_conf_values[-1]
+
     with open(config_file_path,'w') as conf_file:
-        conf_data = (
-            """# Required 
+        conf_data = (f"""# Required 
 title : Demo website    # Title in home page
 url : {url}    # Site URL 
 
 # Jinja templates
 note_template : templates/note_template.html    # Template of note page
 home_template : templates/home_template.html    # Template of home page
-feed_template : templates/feed_template.xml     # Template of feed/rss page
-{a}custom_templates: 
+feed_template : templates/feed_template.xml     # Template of feed/RSS page
+{custom_needed}custom_templates: 
 
 # Directories
-home_path : public      # Generated static files 
+home_path : public      # Generated static files, served from here
 content_path : content  # Markdown files (define page contents and front-matter metadata)
 resource_path : static  # Static assets (css, js, image, etc.) 
 
@@ -35,11 +36,7 @@ site-title : Demo Site Title!
 css : demo.css 
 desc : {desc}
 mail : some@mail.com
-            """).format(
-            url = url, 
-            desc = desc, 
-            a = a
-            )
+            """)
         conf_file.write(conf_data)
         print(f"Created config.yml at {config_file_path}")
 

--- a/sohoj/creator.py
+++ b/sohoj/creator.py
@@ -195,9 +195,8 @@ def create_home_template(project_folder):
 </body>
 </html>""")
         temp_file.write(temp_data)
-        print(f'Created home_template.html at: {project_folder}')
+        print(f'Created home_template.html at: {templates_path}')
     
-
 def create_note_template(project_folder):
     templates_path = path.join(project_folder, 'templates')
     with open(path.join(templates_path,'note_template.html'),'w') as temp_file:
@@ -235,7 +234,125 @@ def create_note_template(project_folder):
 </body>
 </html>""")
             temp_file.write(temp_data)
-            print(f'Created note_template.html at: {project_folder}')
+            print(f'Created note_template.html at: {templates_path}')
+
+def create_feed_template(project_folder):
+    templates_path = path.join(project_folder, 'templates')
+    with open(path.join(templates_path,'feed_template.xml'),'w') as feed_file:
+        feed_data = (
+            """<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+
+ <channel>
+  <title>{{title}}</title>
+  <atom:link href="{{ url }}" rel="self" type="application/rss+xml" />
+  <link>{{ url }}</link>
+  <description>{{ subtitle }}</description>
+  <lastBuildDate>{{ last_date.strftime('%a, %d %b %Y %H:%M:%S GMT') }}</lastBuildDate>
+  <language>en-IN</language>
+
+  <image>
+   <url>{{ config.get('url') }}/{{ config.get('pht') }}</url>
+   <title>{{ title }}</title>
+   <link>{{ url }}</link>
+   <width>32</width>
+   <height>32</height>
+  </image>
+
+  {% for post in posts %}{% if (post.showInHome is undefined) or post.showInHome %}
+  <item>
+   <title>{{ post.title }}</title>
+   <link>{{ config.get('url') }}{{ post.url }}</link>
+   <pubDate>{{ post.date.strftime('%a, %d %b %Y %H:%M:%S GMT') }}</pubDate>
+   <guid isPermaLink="false">{{ config.get('url') }}{{ post.url }}</guid>
+			<description><![CDATA[{{ post.subtitle }} - {{ post.note }} ]]></description>
+  </item>
+  {% endif %}{% endfor %}
+ </channel>""")
+        feed_file.write(feed_data)
+        print(f'Created feed_template.xml at: {templates_path}.')
+
+def create_header(project_folder):
+    content_path = path.join(project_folder, 'content')
+    with open(path.join(content_path,'header.md'),'w') as header_file:
+        header_data = (
+            """<nav> From content/header.md //
+<a href="/">homepage</a
+</nav>
+        """)
+        header_file.write(header_data)
+        print(f'Created header at: {content_path}.')
+    
+
+def create_footer(project_folder):
+    content_path = path.join(project_folder, 'content')
+    with open(path.join(content_path,'footer.md'),'w') as footer_file:
+        footer_data = (
+            """<a href="/">homepage</a> //
+<a href="https://github.com">git</a> //
+<a href="https://linkedin.com">linkedin</a> 
+*   powered by [Rupantar](/https://github.com/bhodrolok/rupantar)
+        """)
+        footer_file.write(footer_data)
+        print(f'Created footer at: {content_path}.')
+
+
+def create_home(project_folder):
+    content_path = path.join(project_folder, 'content')
+    with open(path.join(content_path,'footer.md'),'w') as homepage_file:
+        homepage_data = (
+            """Welcome to Rupantar.
+<br> This is a sample homepage which can be edited at /content/home.md
+
+** Rupantar links: **
+*   [Documentation](/).
+*   [Source code](/).
+        """)
+        homepage_file.write(homepage_data)
+        print(f'Created homepage at: {content_path}.')
+
+
+def create_example_blog(project_folder):
+    content_path = path.join(project_folder, 'content')
+    posts_path = path.join(content_path, 'notes')
+    with open(path.join(posts_path,'example_blog.md'),'w') as post_file:
+        post_data = (
+            """---
+title : "Sample Blog."
+subtitle : "Sample subtitle"
+date : {t}
+---
+
+# This is a sample note page which can be edited/renamed at /content/note/blog1.md
+# This is heading 1
+
+## This is heading 2
+
+### and so on....
+
+**Bold**
+
+*italic*
+
+* list item 1
+* list item 2
+
+1. ordered list
+2. ordered list
+
+[About Markdown](https://daringfireball.net/projects/markdown/)
+[Markdown syntax guide](/https://www.markdownguide.org/basic-syntax/)
+
+| Syntax      | Description |
+| ----------- | ----------- |
+| Header      | Title       |
+| Paragraph   | Text        |
+
+
+Sample paragraph is written like this with lorem ipsum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+        """).format(t=datetime.now().strftime("%Y-%m-%d"))
+        post_file.write(post_data)
+        print(f'Example blog created at {posts_path}.')
 
 
 
@@ -330,7 +447,13 @@ def create_project(project_folder):
         #create_templates(project_folder)
         create_home_template(project_folder)
         create_note_template(project_folder)
+        create_feed_template(project_folder)
         #create_content(project_folder)
+        create_header(project_folder)
+        create_footer(project_folder)
+        create_home(project_folder)
+        create_example_blog(project_folder)
+
         print(f"Project skeleton created at: {project_folder}")
     except:
         print("while generating pidgey "+ project_folder + ", some issue occured.")

--- a/sohoj/creator.py
+++ b/sohoj/creator.py
@@ -29,122 +29,7 @@ mail : some@mail.com
         conf_file.write(conf_data)
         print(f"Created config.yml at {config_file_path}")
 
-
-
-def create_templates(project_folder):
-    templates_path = path.join(project_folder, 'templates')
-    with open(path.join(templates_path,'home_template.html'),'w') as f:
-        conf_data = (
-        """<!DOCTYPE html>
-<html lang="en-IN" data-theme="dark">
-
-<head>
-<meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="description" content=" {{ config.get('desc') }}">
-<title>{{ config.get('site-title') }}</title>
-<link rel="stylesheet" type="text/css" media="screen" href="{{ config.get('css') }}" />
-<link rel="alternate" type="application/atom+xml" title="Recent blog posts" href="/rss.xml">
-</head>
-
-<body>
-<header>
-<h1><a href="/">{% filter lower %} {{ title }} {% endfilter %}</a></h1>
-{{ header }}
-</header>
-<section>
-{{article}}
-<ul>
-{% for post in posts %}{% if (post.showInHome is undefined) or post.showInHome %}
-<li>{{ post.date.strftime('%d %m %Y') }} ; <a href="{{ post.url }}">{% filter lower %} {{ post.title }} {% endfilter %}</a></li>
-{% endif %}{% endfor %}
-{% if nextpage %} <a href="{{ nextpage }}">Older Notes >> </a> {% endif %}
-</ul>
-</section>
-<footer>
-{{ footer }}
-</footer>
-</body>
-</html>
-            """)
-        f.write(conf_data)
-        print('home_template created.')
-
-    with open(path.join(project_folder,'template','note_template.html'),'w') as f:
-        conf_data = (
-            """<!DOCTYPE html>
-<html lang="en" data-theme="dark">
-<head>
-<meta charset="utf-8">
-
-<title>{{ post_title }}</title>
-
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="description" content=" {{ post_subtitle }}">
-
-<link rel="stylesheet" type="text/css" media="screen" href="{{ config.get('css') }}" />
-<link rel="alternate" type="application/atom+xml" title="Recent blog posts" href="/rss.xml">
-{% if metad %}  {{ metad }} {% endif %}
-</head>
-
-<body>
-<header>
-<h1>{{ post_title }} </h1>  
-</header>
-<article>
-{{ article }}
-{% if date %} 
-<p># Last updated on <time>{{ date.strftime('%d %b %Y') }}.</time></p>
-{% endif %}
-</article>
-<footer>
-{{ footer }}
-</footer>
-</body>
-</html>
-            """)
-        f.write(conf_data)
-        print('note template created.')
-
-    with open(path.join(project_folder,'template','feed_template.xml'),'w') as f:
-        conf_data = (
-            """<?xml version="1.0" encoding="UTF-8"?>
-<rss version="2.0">
-
- <channel>
-  <title>{{title}}</title>
-  <atom:link href="{{ url }}" rel="self" type="application/rss+xml" />
-  <link>{{ url }}</link>
-  <description>{{ subtitle }}</description>
-  <lastBuildDate>{{ last_date.strftime('%a, %d %b %Y %H:%M:%S GMT') }}</lastBuildDate>
-  <language>en-IN</language>
-
-  <image>
-   <url>{{ config.get('url') }}/{{ config.get('pht') }}</url>
-   <title>{{ title }}</title>
-   <link>{{ url }}</link>
-   <width>32</width>
-   <height>32</height>
-  </image>
-
-  {% for post in posts %}{% if (post.showInHome is undefined) or post.showInHome %}
-  <item>
-   <title>{{ post.title }}</title>
-   <link>{{ config.get('url') }}{{ post.url }}</link>
-   <pubDate>{{ post.date.strftime('%a, %d %b %Y %H:%M:%S GMT') }}</pubDate>
-   <guid isPermaLink="false">{{ config.get('url') }}{{ post.url }}</guid>
-			<description><![CDATA[{{ post.subtitle }} - {{ post.note }} ]]></description>
-  </item>
-  {% endif %}{% endfor %}
- </channel>
-            """)
-        f.write(conf_data)
-        print('rss template created.')
-        f.close()
-
-
+# templates
 def create_home_template(project_folder):
     templates_path = path.join(project_folder, 'templates')
     with open(path.join(templates_path,'home_template.html'),'w') as temp_file:
@@ -272,6 +157,7 @@ def create_feed_template(project_folder):
         feed_file.write(feed_data)
         print(f'Created feed_template.xml at: {templates_path}.')
 
+# content/ data
 def create_header(project_folder):
     content_path = path.join(project_folder, 'content')
     with open(path.join(content_path,'header.md'),'w') as header_file:
@@ -283,7 +169,6 @@ def create_header(project_folder):
         header_file.write(header_data)
         print(f'Created header at: {content_path}.')
     
-
 def create_footer(project_folder):
     content_path = path.join(project_folder, 'content')
     with open(path.join(content_path,'footer.md'),'w') as footer_file:
@@ -295,7 +180,6 @@ def create_footer(project_folder):
         """)
         footer_file.write(footer_data)
         print(f'Created footer at: {content_path}.')
-
 
 def create_home(project_folder):
     content_path = path.join(project_folder, 'content')
@@ -310,7 +194,6 @@ def create_home(project_folder):
         """)
         homepage_file.write(homepage_data)
         print(f'Created homepage at: {content_path}.')
-
 
 def create_example_blog(project_folder):
     content_path = path.join(project_folder, 'content')
@@ -354,78 +237,24 @@ Sample paragraph is written like this with lorem ipsum. Lorem ipsum dolor sit am
         post_file.write(post_data)
         print(f'Example blog created at {posts_path}.')
 
-
-
-def create_content(project_folder):
-    with open(path.join(project_folder,'content','header.md'),'w') as f:
-        conf_data = (
-            """*   [Home](/)
-*   [Other Links](/)
-*   [Edit content/header.md](/)
-            """)
-        f.write(conf_data)
-        print('header created.')
-
-    with open(path.join(project_folder,'content','footer.md'),'w') as f:
-        conf_data = (
-            """*   [Home](/)
-*   [RSS](/)
-*   [Edit content/footer.md](/)
-*   powered by [Pidgeotto](/)
-            """)
-        f.write(conf_data)
-        print('footer created.')
-
-    with open(path.join(project_folder,'content','home.md'),'w') as f:
-        conf_data = (
-            """Welcome to Pidgeotto.
-<br> This is a sample homepage which can be edited at /content/home.md
-
-** Pidgeotto links: **
-*   [Documentation](/).
-*   [Github Source](/).
-        """)
-        f.write(conf_data)
-        print('footer created.')
-    
-    with open(path.join(project_folder,'content','note','blog1.md'),'w') as f:
-        conf_data = (
+def createNote(project_folder, post_filename, show_home_page = True):
+    try:
+        if not post_filename.lower().endswith('.md'):
+            post_filename+='.md'
+        with open(path.join(project_folder,'content','note',post_filename),'w') as f:
+            conf_data = (
             """---
-title : "Sample Blog."
-subtitle : "Sample subtitle"
+title : "Title"
+subtitle : "Subtitle"
+showInHome : {s}
 date : {t}
 ---
-
-# This is a sample note page which can be edited/renamed at /content/note/blog1.md
-# This is heading 1
-
-## This is heading 2
-
-### This is heading 3
-
-#### This is heading 4
-
-##### This is heading 5
-
-###### This is heading 6
-
-**Bold**
-
-*italic*
-
-* list
-* list
-
-1. ordered list
-2. ordered list
-
-[link](/)
-
-Sample paragraph is written like this with lorem ipsum. Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        """).format(t=datetime.now().strftime("%Y-%m-%d"))
-        f.write(conf_data)
-        print('sample blog created.')
-
+            """).format(t=datetime.now().strftime("%Y-%m-%d"), s=show_home_page)
+            f.write(conf_data)
+            print(post_filename+" is created at content/note/"+post_filename )
+    except:
+        print("while generating page "+post_filename+", some issue occured.")
+        print("This can be due to \n\t1. Not a pidgey directory. \n\t2. Invalid filename")
 
 def create_project(project_folder):
     try:
@@ -459,21 +288,3 @@ def create_project(project_folder):
         print("while generating pidgey "+ project_folder + ", some issue occured.")
         print("This can be due to \n\t1. Pidgey already exists.\n\t2. Memory issue.\n\t3. Invalid input.\n\t4. If none of these, report to developer.")
 
-def createNote(project_folder, post_filename, show_home_page = True):
-    try:
-        if not post_filename.lower().endswith('.md'):
-            post_filename+='.md'
-        with open(path.join(project_folder,'content','note',post_filename),'w') as f:
-            conf_data = (
-            """---
-title : "Title"
-subtitle : "Subtitle"
-showInHome : {s}
-date : {t}
----
-            """).format(t=datetime.now().strftime("%Y-%m-%d"), s=show_home_page)
-            f.write(conf_data)
-            print(post_filename+" is created at content/note/"+post_filename )
-    except:
-        print("while generating page "+post_filename+", some issue occured.")
-        print("This can be due to \n\t1. Not a pidgey directory. \n\t2. Invalid filename")

--- a/sohoj/creator.py
+++ b/sohoj/creator.py
@@ -8,22 +8,27 @@ def create_config(project_folder):
     with open(config_file_path,'w') as conf_file:
         conf_data = (
             """# Required 
-title : Demo website
-url : yourdomain.tld
-note_template : template/note_template.html   # Template of note page
-home_template : template/home_template.html   # Template of home page
-feed_template : template/feed_template.xml   # Template of feed/rss page
-home_path : public  # After built, static files will be generated here
-content_path : content # All post notes markdown location
-resource_path : static # All css, js, image location
-home_md : content/home.md # Homepage content
-header_md : content/header.md # Header content
-footer_md : content/footer.md # Footer content
+title : Demo website    # Title in home page
+url : domain.tld    # Site URL 
 
-# Optional Configuration, Add your own configs here
-site-title : Demo Pidgeotto
-css : demo.css
-desc : Write anything that human and machine can understand.
+# Jinja templates
+note_template : templates/note_template.html    # Template of note page
+home_template : templates/home_template.html    # Template of home page
+feed_template : templates/feed_template.xml     # Template of feed/rss page
+
+# Directories
+home_path : public      # Generated static files 
+content_path : content  # Markdown files (define page contents and front-matter metadata)
+resource_path : static  # Static assets (css, js, image, etc.) 
+
+home_md : content/home.md       # Home page stuff
+header_md : content/header.md   # Header 
+footer_md : content/footer.md   # Footer 
+
+# Optional (Add custom configs here)
+site-title : Demo Pidgeotto                     
+css : demo.css 
+desc : just another little corner on the interwebs.
 mail : some@mail.com
             """)
         conf_file.write(conf_data)
@@ -237,7 +242,30 @@ Sample paragraph is written like this with lorem ipsum. Lorem ipsum dolor sit am
         post_file.write(post_data)
         print(f'Example blog created at {posts_path}.')
 
-def createNote(project_folder, post_filename, show_home_page = True):
+# static asset(s)
+def create_static(project_folder):
+    static_path = path.join(project_folder, 'static')
+    with open(path.join(static_path, 'demo.css'), 'w') as css_file:
+        # adapted from nih.ar
+        css_data = (
+            """:root{--bg:#DDD;--txt:#333;--thm:#357670}
+body{background:var(--bg);color:var(--txt);font:1.2em/1.6em sans-serif;max-width:900px;margin:7% auto auto;padding:0 5%}
+h1,h2,h3{font-size:1em}
+a{color:var(--thm);text-decoration:none}
+a:hover{color:var(--bg);background-color:var(--thm);padding-top:3px}
+header h1{color:var(--thm);font-size:1.2em;display:inline}
+nav{font-weight:bold;display:inline}
+ul{padding-left:20px;list-style-type:'-- ';line-height:1.4}
+pre{border:1px solid var(--txt);padding:1em;overflow-x:auto}
+code{background:var(--thm)}
+pre code{background:none}
+@media (prefers-color-scheme: dark){:root{--bg:#080C0C;--txt:#C6DFDD;--thm:#42938C}}
+@media(max-width:480px){body{font:1em/1.4em sans-serif}}
+        """)
+        css_file.write(css_data)
+        print(f'demo.css created at {static_path}')
+
+def create_note(project_folder, post_filename, show_home_page = True):
     try:
         if not post_filename.lower().endswith('.md'):
             post_filename+='.md'
@@ -277,12 +305,14 @@ def create_project(project_folder):
         create_home_template(project_folder)
         create_note_template(project_folder)
         create_feed_template(project_folder)
+
+        create_static(project_folder)
         #create_content(project_folder)
         create_header(project_folder)
         create_footer(project_folder)
         create_home(project_folder)
         create_example_blog(project_folder)
-
+        # Finish init
         print(f"Project skeleton created at: {project_folder}")
     except:
         print("while generating pidgey "+ project_folder + ", some issue occured.")

--- a/sohoj/creator.py
+++ b/sohoj/creator.py
@@ -1,12 +1,14 @@
-from os import mkdir, path
+from os import chdir, mkdir, path
 from datetime import datetime
 
 
-def createConfig(pidgeyName):
-    with open(path.join(pidgeyName,'config.yml'),'w') as f:
+def create_config(project_folder):
+    # Default name is config.yml + located in root of project folder
+    config_file_path = path.join(project_folder, 'config.yml')
+    with open(config_file_path,'w') as conf_file:
         conf_data = (
-            """# Mandatory Configuration
-title : Demo pidgeotto website
+            """# Required 
+title : Demo website
 url : yourdomain.tld
 note_template : template/note_template.html   # Template of note page
 home_template : template/home_template.html   # Template of home page
@@ -24,12 +26,14 @@ css : demo.css
 desc : Write anything that human and machine can understand.
 mail : some@mail.com
             """)
-        f.write(conf_data)
-        print('config.yml created.')
+        conf_file.write(conf_data)
+        print(f"Created config.yml at {config_file_path}")
 
 
-def createTemplates(pidgeyName):
-    with open(path.join(pidgeyName,'template','home_template.html'),'w') as f:
+
+def create_templates(project_folder):
+    templates_path = path.join(project_folder, 'templates')
+    with open(path.join(templates_path,'home_template.html'),'w') as f:
         conf_data = (
         """<!DOCTYPE html>
 <html lang="en-IN" data-theme="dark">
@@ -67,7 +71,7 @@ def createTemplates(pidgeyName):
         f.write(conf_data)
         print('home_template created.')
 
-    with open(path.join(pidgeyName,'template','note_template.html'),'w') as f:
+    with open(path.join(project_folder,'template','note_template.html'),'w') as f:
         conf_data = (
             """<!DOCTYPE html>
 <html lang="en" data-theme="dark">
@@ -104,7 +108,7 @@ def createTemplates(pidgeyName):
         f.write(conf_data)
         print('note template created.')
 
-    with open(path.join(pidgeyName,'template','feed_template.xml'),'w') as f:
+    with open(path.join(project_folder,'template','feed_template.xml'),'w') as f:
         conf_data = (
             """<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0">
@@ -141,8 +145,102 @@ def createTemplates(pidgeyName):
         f.close()
 
 
-def createContent(pidgeyName):
-    with open(path.join(pidgeyName,'content','header.md'),'w') as f:
+def create_home_template(project_folder):
+    templates_path = path.join(project_folder, 'templates')
+    with open(path.join(templates_path,'home_template.html'),'w') as temp_file:
+        temp_data = (
+        """<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+    <title>{{ config.get('site-title') }}</title>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content=" {{ config.get('desc') }}">
+    <!--<link rel="shortcut icon" href="{{ config.get('fav') }}" />-->
+    <link rel="alternate" type="application/atom+xml" title="Recent blog posts" href="/rss.xml">
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ config.get('css') }}" />
+</head>
+
+<body>
+    <header>
+    <h1><a href="/">{% filter lower %} {{ title }} {% endfilter %}</a></h1>
+    {{ header }}
+    </header>
+
+    <section>
+    <!-- article = markdown contents beyond the '---title=...etc.---' -->
+    {{article}}
+    <ul>
+    {% for post in posts %}
+    {% if (post.showInHome is undefined) or post.showInHome %}
+    <li>
+    <time>
+    {{ post.date.strftime('%Y-%m-%d') }}
+    </time> : <a href="{{ post.url }}">{% filter lower %} {{ post.title }} {% endfilter %}</a>
+    </li>
+    {% endif %}
+    {% endfor %}
+    </ul>
+    </section>
+
+    <!--
+    <section>
+    {{ config.get('homefooter') }}
+    </section>
+    -->
+    <footer>
+    {{ footer }}
+    </footer>
+</body>
+</html>""")
+        temp_file.write(temp_data)
+        print(f'Created home_template.html at: {project_folder}')
+    
+
+def create_note_template(project_folder):
+    templates_path = path.join(project_folder, 'templates')
+    with open(path.join(templates_path,'note_template.html'),'w') as temp_file:
+            temp_data = (
+            """<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+    <meta charset="utf-8">
+    <title>{{ post_title }}</title>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content=" {{ post_subtitle }}">
+    <meta property="og:type" content="article" >
+    <meta property="og:url" content="{{ url }}" >
+    <meta property="article:modified_time" content="{{ date.strftime('%Y-%m-%d') }}" >
+
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ config.get('css') }}" />
+    <link rel="alternate" type="application/atom+xml" title="Recent blog posts" href="/rss.xml">
+    {% if metad %}  {{ metad }} {% endif %}
+</head>
+
+<body>
+    <header>
+    <h1>{{ post_title }} </h1>  
+    </header>
+    <article>
+    {{ article }}
+    {% if date %} 
+    <p># Last updated on <time>{{ date.strftime('%d %b %Y') }}.</time></p>
+    {% endif %}
+    </article>
+    <footer>
+    {{ footer }}
+    </footer>
+</body>
+</html>""")
+            temp_file.write(temp_data)
+            print(f'Created note_template.html at: {project_folder}')
+
+
+
+def create_content(project_folder):
+    with open(path.join(project_folder,'content','header.md'),'w') as f:
         conf_data = (
             """*   [Home](/)
 *   [Other Links](/)
@@ -151,7 +249,7 @@ def createContent(pidgeyName):
         f.write(conf_data)
         print('header created.')
 
-    with open(path.join(pidgeyName,'content','footer.md'),'w') as f:
+    with open(path.join(project_folder,'content','footer.md'),'w') as f:
         conf_data = (
             """*   [Home](/)
 *   [RSS](/)
@@ -161,7 +259,7 @@ def createContent(pidgeyName):
         f.write(conf_data)
         print('footer created.')
 
-    with open(path.join(pidgeyName,'content','home.md'),'w') as f:
+    with open(path.join(project_folder,'content','home.md'),'w') as f:
         conf_data = (
             """Welcome to Pidgeotto.
 <br> This is a sample homepage which can be edited at /content/home.md
@@ -173,7 +271,7 @@ def createContent(pidgeyName):
         f.write(conf_data)
         print('footer created.')
     
-    with open(path.join(pidgeyName,'content','note','blog1.md'),'w') as f:
+    with open(path.join(project_folder,'content','note','blog1.md'),'w') as f:
         conf_data = (
             """---
 title : "Sample Blog."
@@ -212,19 +310,30 @@ Sample paragraph is written like this with lorem ipsum. Lorem ipsum dolor sit am
         print('sample blog created.')
 
 
-def createPidgey(pidgeyName):
+def create_project(project_folder):
     try:
-        mkdir(pidgeyName)
-        print("pidgey " + pidgeyName + " created.")
-        mkdir(path.join(pidgeyName,'template'))
-        mkdir(path.join(pidgeyName,'static'))
-        mkdir(path.join(pidgeyName,'content'))
-        mkdir(path.join(pidgeyName,'content','note'))
-        createConfig(pidgeyName)
-        createTemplates(pidgeyName)
-        createContent(pidgeyName)
+        # Create project folder
+        mkdir(project_folder)
+        # Use location of current file to get to parent directory(oustide sohoj/)
+        script_dir = path.dirname(path.dirname(path.abspath(__file__)))
+        # Location of project folder with all contents (absolute)
+        project_folder = path.join(script_dir, project_folder)
+        # Change cwd to new project folder
+        chdir((project_folder))
+        # Create directories for storing: Templates, static assets and page data (under contents)
+        mkdir('templates')
+        mkdir('content')
+        mkdir('static')
+        mkdir(path.join('content','notes'))
+        # Generate default config, templates and site contents
+        create_config(project_folder)
+        #create_templates(project_folder)
+        create_home_template(project_folder)
+        create_note_template(project_folder)
+        #create_content(project_folder)
+        print(f"Project skeleton created at: {project_folder}")
     except:
-        print("while generating pidgey "+ pidgeyName + ", some issue occured.")
+        print("while generating pidgey "+ project_folder + ", some issue occured.")
         print("This can be due to \n\t1. Pidgey already exists.\n\t2. Memory issue.\n\t3. Invalid input.\n\t4. If none of these, report to developer.")
 
 def createNote(project_folder, post_filename, show_home_page = True):

--- a/sohoj/creator.py
+++ b/sohoj/creator.py
@@ -2,19 +2,24 @@ from os import chdir, mkdir, path
 from datetime import datetime
 
 
-def create_config(project_folder):
+def create_config(project_folder, user_choices):
     # Default name is config.yml + located in root of project folder
     config_file_path = path.join(project_folder, 'config.yml')
+    url = user_choices[0] if (user_choices[0] is not None) else 'yourdomain.tld', 
+    desc = user_choices[1] if (user_choices[1] is not None) else 'Just another little corner on the interwebs', 
+    a = '' if ( user_choices[2] == 'Y' ) else '#'
+    print(f"Choices:\nSite URL: {url}\nSite Description: {desc}\nCustom: {a}")
     with open(config_file_path,'w') as conf_file:
         conf_data = (
             """# Required 
 title : Demo website    # Title in home page
-url : domain.tld    # Site URL 
+url : {url}    # Site URL 
 
 # Jinja templates
 note_template : templates/note_template.html    # Template of note page
 home_template : templates/home_template.html    # Template of home page
 feed_template : templates/feed_template.xml     # Template of feed/rss page
+{a}custom_templates: 
 
 # Directories
 home_path : public      # Generated static files 
@@ -26,11 +31,15 @@ header_md : content/header.md   # Header
 footer_md : content/footer.md   # Footer 
 
 # Optional (Add custom configs here)
-site-title : Demo Pidgeotto                     
+site-title : Demo Site Title!                     
 css : demo.css 
-desc : just another little corner on the interwebs.
+desc : {desc}
 mail : some@mail.com
-            """)
+            """).format(
+            url = url, 
+            desc = desc, 
+            a = a
+            )
         conf_file.write(conf_data)
         print(f"Created config.yml at {config_file_path}")
 
@@ -284,7 +293,7 @@ date : {t}
         print("while generating page "+post_filename+", some issue occured.")
         print("This can be due to \n\t1. Not a pidgey directory. \n\t2. Invalid filename")
 
-def create_project(project_folder):
+def create_project(project_folder, user_choices):
     try:
         # Create project folder
         mkdir(project_folder)
@@ -300,7 +309,7 @@ def create_project(project_folder):
         mkdir('static')
         mkdir(path.join('content','notes'))
         # Generate default config, templates and site contents
-        create_config(project_folder)
+        create_config(project_folder, user_choices)
         #create_templates(project_folder)
         create_home_template(project_folder)
         create_note_template(project_folder)

--- a/start.py
+++ b/start.py
@@ -32,7 +32,7 @@ def main():
     if args.type == "init" and args.mool:
         creator.create_project(args.mool)
     elif args.type == "new" and args.mool and args.name:
-        creator.createNote(args.mool, args.name, args.show_home)
+        creator.create_note(args.mool, args.name, args.show_home)
     elif args.type == 'build' and args.mool:
         builder.buildPidgey(args.mool, args.config)
     elif args.type == 'serve' and args.mool:

--- a/start.py
+++ b/start.py
@@ -8,8 +8,9 @@ def main():
     parser.add_argument("-v", "--version", action="version", version=f"{__version__}" )
     subparsers = parser.add_subparsers(dest='type', help='Supported commands', required=True)
     
-    parser_init = subparsers.add_parser('init', help='Create new skeleton project at provided directory. Default config.')
+    parser_init = subparsers.add_parser('init', help='Create new rupantar project skeleton at provided directory.')
     # TODO prompt for config fields into --> conf_data("{a}{b}").format(a=input1,b=input2)etc.
+    # TODO add flag with no value if just want to init with all default (skip prompt!)
     parser_init.add_argument("mool", help="Name of project. Path relative to cwd.")
 
     parser_new = subparsers.add_parser('new', help="Create new post at provided rupantar project's content/note directory.")
@@ -17,20 +18,31 @@ def main():
     parser_new.add_argument("name", help="Filename of post without extension.")
     parser_new.add_argument("-sh", dest="show_home", help="If the post is to be shown in home page. Default True.", type=lambda x: x == 'True')
     
-    parser_build = subparsers.add_parser('build', help='Build and generate static website pages from template and data. Default output directory is public/.')
+    parser_build = subparsers.add_parser('build', help='Build rupantar project, generate static pages. Deletes pre-existing output directory and creates a new one.')
     parser_build.add_argument("mool", help="Name of project directory. Path relative to cwd.")
     parser_build.add_argument("-c", "--config", nargs='?', help="Name of config file to use. Path relative to project directory. Default config.yml")
 
     parser_serve = subparsers.add_parser('serve', help='Start a local server for serving and previewing generated pages.')
     parser_serve.add_argument("mool", help="Name of project directory. Path relative to cwd.")
     parser_serve.add_argument("-c", "--config", nargs='?', help="Name of config file to use. Path relative to project directory. Default config.yml")
-    parser_serve.add_argument("-p", "--port", help="Network port where the server will listen for requests. Default is random ephemeral port.", type=int)
+    parser_serve.add_argument("-p", "--port", help="Network port where the server will listen for requests. Default random ephemeral port.", type=int)
     parser_serve.add_argument("-i", "--interface", help="Network interface to bind the server to. Default localhost/loopback interface.")
     
     args = parser.parse_args()
     
     if args.type == "init" and args.mool:
-        creator.create_project(args.mool)
+        # Interactive prompts for setting some default config.yml fields
+        print("Hello there!\nPlease answer the following questions to set up your website's configuration!")
+        print("Questions are completely optional and can be skipped by leaving them blank.")
+        print("Choices made can be updated by modifying the config.yml file at the project directory!")
+        user_prompts = []
+        site_url = input("Site URL? (yourdomain.tld): ")
+        user_prompts.append(site_url.replace(" ", ""))
+        site_desc = input("Site description? : ")
+        user_prompts.append(site_desc.replace(" ", ""))
+        need_custom = input("Do you want to add custom templates? (Y/N): ")
+        user_prompts.append(need_custom.replace(" ", ""))
+        creator.create_project(args.mool, user_prompts)
     elif args.type == "new" and args.mool and args.name:
         creator.create_note(args.mool, args.name, args.show_home)
     elif args.type == 'build' and args.mool:

--- a/start.py
+++ b/start.py
@@ -25,12 +25,12 @@ def main():
     parser_serve.add_argument("mool", help="Name of project directory. Path relative to cwd.")
     parser_serve.add_argument("-c", "--config", nargs='?', help="Name of config file to use. Path relative to project directory. Default config.yml")
     parser_serve.add_argument("-p", "--port", help="Network port where the server will listen for requests. Default is random ephemeral port.", type=int)
-    parser_serve.add_argument("-i", "--interface", help="Network interface to bind the server to. Default localhost/loopback interface")
+    parser_serve.add_argument("-i", "--interface", help="Network interface to bind the server to. Default localhost/loopback interface.")
     
     args = parser.parse_args()
     
     if args.type == "init" and args.mool:
-        creator.createPidgey(args.mool)
+        creator.create_project(args.mool)
     elif args.type == "new" and args.mool and args.name:
         creator.createNote(args.mool, args.name, args.show_home)
     elif args.type == 'build' and args.mool:


### PR DESCRIPTION
* Now when running  `init`, program prompts user thrice for setting up some values in the config.yml (base site URL, site description, and if they want  to add custom templates)
    * Basic handling done so if user passes in nothing or just whitespaces, use default values. 
*  Changed structure of `creator.py`,  `create_templates()` --> 3 funcs for creating Jinja2 templates for home, note/posts and RSS feed. Same with `create_content`.
* Also added function to create basic CSS for project upon `init`. ( #5 ) 